### PR TITLE
Add _malloc to the EXPORTED_FUNCTIONS in the WASM Makefile.

### DIFF
--- a/dvipdfm.wasm/Makefile
+++ b/dvipdfm.wasm/Makefile
@@ -7,7 +7,7 @@ CFLAGS			= 	$(DEBUGFLAGS) -DHAVE_ZLIB -s USE_LIBPNG=1 -fno-rtti -fno-exceptions
 LDFLAGS 		=  	$(DEBUGFLAGS)  --js-library library.js  \
 					-s ENVIRONMENT="web" \
   				-s USE_LIBPNG=1 --pre-js pre.js \
- 					-s EXPORTED_FUNCTIONS='["_compilePDF", "_setMainEntry", "_main"]' -s NO_EXIT_RUNTIME=1 \
+ 					-s EXPORTED_FUNCTIONS='["_compilePDF", "_setMainEntry", "_main", "_malloc"]' -s NO_EXIT_RUNTIME=1 \
   					-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_RUNTIME_METHODS=["cwrap"] -fno-rtti -fno-exceptions
 CXX_LINK 		= 	$(CXX) -o $@ $(LDFLAGS)
 

--- a/pdftex.wasm/Makefile
+++ b/pdftex.wasm/Makefile
@@ -56,7 +56,7 @@ all: $(PROJECT_NAME)
 
 $(PROJECT_NAME): $(HEADERS) $(TEXOBJECTS) $(PDFOBJECTS) $(EPDFOBJECTS)
 	@$(CXX_LINK) $(TEXOBJECTS) $(PDFOBJECTS) $(EPDFOBJECTS) xpdf/xpdf.a  --js-library library.js  --pre-js pre.js \
-	-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry"]' \
+	-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry", "_malloc"]' \
 	-s EXPORTED_RUNTIME_METHODS=["cwrap"] -s NO_EXIT_RUNTIME=1 -s ALLOW_MEMORY_GROWTH=1 && \
 	echo -e "\033[32m[DONE]\033[0m $(PROJECT_NAME)" || \
 	echo -e "\033[31m[ERROR]\033[0m $(PROJECT_NAME)"

--- a/xetex.wasm/Makefile
+++ b/xetex.wasm/Makefile
@@ -12,7 +12,7 @@ LDFLAGS 		= 	$(DEBUGFLAGS) --js-library library.js \
 					-s USE_LIBPNG=1 \
 					--pre-js pre.js \
 					-s ENVIRONMENT="web" \
-					-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry"]' -s NO_EXIT_RUNTIME=1 \
+					-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry", "_malloc"]' -s NO_EXIT_RUNTIME=1 \
 					-s WASM=1 -s EXPORTED_RUNTIME_METHODS=["cwrap"] -s ALLOW_MEMORY_GROWTH=1
 
 LINKFLAG 		= 	$(CXX) -o $@ $(LDFLAGS)


### PR DESCRIPTION
I found the error '_malloc is not defined' in the browser console logs. After adding the export to the Makefile, the problem was resolved.