### PR TITLE
build: export _malloc

### DIFF
--- a/pdftex.wasm/Makefile
+++ b/pdftex.wasm/Makefile
@@ -56,7 +56,7 @@ all: $(PROJECT_NAME)
 
 $(PROJECT_NAME): $(HEADERS) $(TEXOBJECTS) $(PDFOBJECTS) $(EPDFOBJECTS)
 	@$(CXX_LINK) $(TEXOBJECTS) $(PDFOBJECTS) $(EPDFOBJECTS) xpdf/xpdf.a  --js-library library.js  --pre-js pre.js \
-	-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry"]' \
+	-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry", "_malloc"]' \
 	-s EXPORTED_RUNTIME_METHODS=["cwrap"] -s NO_EXIT_RUNTIME=1 -s ALLOW_MEMORY_GROWTH=1 && \
 	echo -e "\033[32m[DONE]\033[0m $(PROJECT_NAME)" || \
 	echo -e "\033[31m[ERROR]\033[0m $(PROJECT_NAME)"

--- a/xetex.wasm/Makefile
+++ b/xetex.wasm/Makefile
@@ -12,7 +12,7 @@ LDFLAGS 		= 	$(DEBUGFLAGS) --js-library library.js \
 					-s USE_LIBPNG=1 \
 					--pre-js pre.js \
 					-s ENVIRONMENT="web" \
-					-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry"]' -s NO_EXIT_RUNTIME=1 \
+					-s EXPORTED_FUNCTIONS='["_compileBibtex", "_compileLaTeX", "_compileFormat", "_main", "_setMainEntry", "_malloc"]' -s NO_EXIT_RUNTIME=1 \
 					-s WASM=1 -s EXPORTED_RUNTIME_METHODS=["cwrap"] -s ALLOW_MEMORY_GROWTH=1
 
 LINKFLAG 		= 	$(CXX) -o $@ $(LDFLAGS)


### PR DESCRIPTION
_malloc is required by the generated JS as tested with https://github.com/emscripten-core/emsdk/commit/85390ce88465e18c1c5d2f8d7f6ed21f3e8e8678